### PR TITLE
Possible fix for Incorrect Log timestamps

### DIFF
--- a/resources/js/Pages/Logs/Index.vue
+++ b/resources/js/Pages/Logs/Index.vue
@@ -86,7 +86,7 @@
                         </td>
                         <td class="px-6 py-3 border-t">{{ log.action }}</td>
                         <td class="px-6 py-3 border-t">{{ log.details }}</td>
-                        <td class="px-6 py-3 border-t">{{ new Date(log.timestamp).toLocaleString() }}</td>
+                        <td class="px-6 py-3 border-t">{{ $moment(log.timestamp).format('lll') }}</td>
                         <td class="px-6 py-3 border-t">{{ log.server }}</td>
                     </tr>
                     <tr v-if="logs.data.length === 0">

--- a/resources/js/Pages/Logs/Index.vue
+++ b/resources/js/Pages/Logs/Index.vue
@@ -69,7 +69,7 @@
                     </td>
                     <td class="px-6 py-3 border-t">{{ log.action }}</td>
                     <td class="px-6 py-3 border-t">{{ log.details }}</td>
-                    <td class="px-6 py-3 border-t">{{ new Date(log.timestamp).toLocaleString() }}</td>
+                    <td class="px-6 py-3 border-t">{{ $moment(log.timestamp).format('lll') }}</td>
                     <td class="px-6 py-3 border-t">{{ log.server }}</td>
                 </tr>
                 <tr v-if="logs.data.length === 0">


### PR DESCRIPTION
I noticed that the Issue #86 didn't seem to apply to unban times where a different method of formatting the date is used. So I applied that different formatting method to the log view as well. If this doesn't fix it then the timestamp are off (what?? how?? why??)