### PR TITLE
Bugfixes: Log seconds missing, Log timezone wrong, Characters not animating

### DIFF
--- a/app/Http/Controllers/LogController.php
+++ b/app/Http/Controllers/LogController.php
@@ -41,6 +41,9 @@ class LogController extends Controller
             $query->where('details', 'like', "%{$details}%");
         }
 
+        // Converting timestamp to UTC
+        $query->selectRaw('*, CONVERT_TZ(`timestamp`, @@session.time_zone, \'+00:00\') as timestamp');
+
         return Inertia::render('Logs/Index', [
             'logs' => LogResource::collection($query->simplePaginate(15)->appends($request->query())),
             'filters' => $request->all(

--- a/app/Http/Controllers/LogController.php
+++ b/app/Http/Controllers/LogController.php
@@ -41,9 +41,6 @@ class LogController extends Controller
             $query->where('details', 'like', "%{$details}%");
         }
 
-        // Converting timestamp to UTC
-        $query->selectRaw('*, CONVERT_TZ(`timestamp`, @@session.time_zone, \'+00:00\') as timestamp');
-
         return Inertia::render('Logs/Index', [
             'logs' => LogResource::collection($query->simplePaginate(15)->appends($request->query())),
             'filters' => $request->all(

--- a/config/database.php
+++ b/config/database.php
@@ -60,6 +60,7 @@ return [
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::MYSQL_ATTR_INIT_COMMAND => 'SET time_zone = \'+00:00\'',
             ]) : [],
         ],
 

--- a/resources/js/Filters/formatSeconds.js
+++ b/resources/js/Filters/formatSeconds.js
@@ -1,7 +1,6 @@
-import Vue from 'vue';
 import moment from 'moment';
 
 // Formatting seconds to human readable time
-Vue.filter("formatSeconds", function(value) {
+export default function(value) {
     return moment.duration(parseInt(value), "seconds").humanize();
 });

--- a/resources/js/Filters/formatTime.js
+++ b/resources/js/Filters/formatTime.js
@@ -1,0 +1,8 @@
+import moment from 'moment';
+
+// Formatting seconds to human readable time
+export default function (value, includeSeconds) {
+    const format = includeSeconds ? 'MMM DD, YYYY h:mm:ss A' : 'lll';
+
+    return moment.utc(value).local().format(format);
+};

--- a/resources/js/Pages/Logs/Index.vue
+++ b/resources/js/Pages/Logs/Index.vue
@@ -86,7 +86,7 @@
                         </td>
                         <td class="px-6 py-3 border-t">{{ log.action }}</td>
                         <td class="px-6 py-3 border-t">{{ log.details }}</td>
-                        <td class="px-6 py-3 border-t">{{ $moment(log.timestamp).format('MMM DD, YYYY h:mm:ss A') }}</td>
+                        <td class="px-6 py-3 border-t">{{ log.timestamp | formatTime(true) }}</td>
                         <td class="px-6 py-3 border-t">{{ log.server }}</td>
                     </tr>
                     <tr v-if="logs.data.length === 0">

--- a/resources/js/Pages/Logs/Index.vue
+++ b/resources/js/Pages/Logs/Index.vue
@@ -86,7 +86,7 @@
                         </td>
                         <td class="px-6 py-3 border-t">{{ log.action }}</td>
                         <td class="px-6 py-3 border-t">{{ log.details }}</td>
-                        <td class="px-6 py-3 border-t">{{ $moment(log.timestamp).format('lll') }}</td>
+                        <td class="px-6 py-3 border-t">{{ $moment(log.timestamp).format('MMM DD, YYYY h:mm:ss A') }}</td>
                         <td class="px-6 py-3 border-t">{{ log.server }}</td>
                     </tr>
                     <tr v-if="logs.data.length === 0">

--- a/resources/js/Pages/Logs/Index.vue
+++ b/resources/js/Pages/Logs/Index.vue
@@ -86,7 +86,7 @@
                         </td>
                         <td class="px-6 py-3 border-t">{{ log.action }}</td>
                         <td class="px-6 py-3 border-t">{{ log.details }}</td>
-                        <td class="px-6 py-3 border-t">{{ new Date(log.timestamp).toLocaleString() }}</td>
+                        <td class="px-6 py-3 border-t">{{ $moment(log.timestamp).format('lll') }}</td>
                         <td class="px-6 py-3 border-t">{{ log.server }}</td>
                     </tr>
                     <tr v-if="logs.data.length === 0">

--- a/resources/js/Pages/Logs/Index.vue
+++ b/resources/js/Pages/Logs/Index.vue
@@ -69,7 +69,7 @@
                     </td>
                     <td class="px-6 py-3 border-t">{{ log.action }}</td>
                     <td class="px-6 py-3 border-t">{{ log.details }}</td>
-                    <td class="px-6 py-3 border-t">{{ new Date(log.timestamp).toLocaleString() }}</td>
+                    <td class="px-6 py-3 border-t">{{ $moment(log.timestamp).format('lll') }}</td>
                     <td class="px-6 py-3 border-t">{{ log.server }}</td>
                 </tr>
                 <tr v-if="logs.data.length === 0">

--- a/resources/js/Pages/Players/Show.vue
+++ b/resources/js/Pages/Players/Show.vue
@@ -47,10 +47,10 @@
 
                 <div class="flex items-center justify-between mb-2">
                     <h2 class="text-lg font-semibold">
-                        Banned by <span class="italic">{{ player.ban.issuer }}</span> <span class="italic" v-if="player.ban.expire">until {{ $moment(player.ban.expireAt).format('lll') }}</span>
+                        Banned by <span class="italic">{{ player.ban.issuer }}</span> <span class="italic" v-if="player.ban.expire">until {{ player.ban.expireAt | formatTime }}</span>
                     </h2>
                     <div class="font-semibold">
-                        {{ $moment(player.ban.timestamp).format('lll') }}
+                        {{ player.ban.timestamp | formatTime }}
                     </div>
                 </div>
 
@@ -204,7 +204,7 @@
                                 </h4>
                             </div>
                             <div class="flex items-center">
-                                <span class="text-muted">{{ $moment(warning.createdAt).format('lll') }}</span>
+                                <span class="text-muted">{{ warning.createdAt | formatTime }}</span>
                                 <inertia-link class="bg-red-500 hover:bg-red-600 font-semibold text-white text-sm rounded py-1 px-3 ml-4" method="DELETE" v-bind:href="'/players/' + warning.player.steamIdentifier + '/warnings/' + warning.id">
                                     <i class="fas fa-trash"></i>
                                 </inertia-link>

--- a/resources/js/Pages/Players/Show.vue
+++ b/resources/js/Pages/Players/Show.vue
@@ -147,8 +147,6 @@
                     <card
                         v-for="(character, index) in characters"
                         :key="character.id"
-                        data-aos="fade-up"
-                        :data-aos-delay="index * 100"
                     >
                         <template #header>
                             <div class="text-center">

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -4,6 +4,7 @@ import Vue from 'vue';
 import PortalVue from 'portal-vue';
 import moment from 'moment';
 import humanizeSeconds from './Filters/humanizeSeconds.js';
+import formatTime from './Filters/formatTime.js';
 
 // Plugins.
 Vue.use(InertiaApp);
@@ -12,8 +13,11 @@ Vue.use(PortalVue);
 // Properties / methods.
 Vue.prototype.$moment = moment;
 
-// Adding the formatSeconds filter
+// Adding the humanizeSeconds filter
 Vue.filter('humanizeSeconds', humanizeSeconds);
+
+// Adding the formatTime filter
+Vue.filter('formatTime', formatTime);
 
 // Create Vue.
 const app = document.getElementById('app');

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,13 +1,16 @@
 import { InertiaApp } from '@inertiajs/inertia-vue';
 import Vue from 'vue';
 import moment from 'moment';
-import './Filters/formatSeconds.js';
+import formatSeconds from './Filters/formatSeconds.js';
 
 // Use inertia plugin.
 Vue.use(InertiaApp);
 
 // Global properties / methods.
 Vue.prototype.$moment = moment;
+
+// Adding the formatSeconds filter
+Vue.filter('formatSeconds', formatSeconds);
 
 // App element.
 const app = document.getElementById('app');


### PR DESCRIPTION
It looks like my "fix" for the EST timestamp accidentally removed the seconds from the log (which are quite important for research). This commit brings them back.

Regarding the incorrect timestamp, it looks like the timestamp is somehow in EST, I don't know how one could fix that bug without an ugly workaround.