### PR TITLE
[Controllers\MapController] Added LOCK_MAP_TO_ROLE.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,3 +60,5 @@ VUE_APP_LOCALE=en-us
 OP_FW_SERVERS=c3s1.op-framework.com,c3s2.op-framework.com
 OP_FW_TOKEN=mytoken
 DEV_API_KEY=some_random_token
+
+LOCK_MAP_TO_ROLE=false

--- a/app/Http/Controllers/MapController.php
+++ b/app/Http/Controllers/MapController.php
@@ -22,10 +22,9 @@ class MapController extends Controller
      */
     public function index(Request $request): Response
     {
-        if (!PermissionHelper::hasPermission($request, PermissionHelper::PERM_LIVEMAP)) {
+        if(env('LOCK_MAP_TO_ROLE', true) && !PermissionHelper::hasPermission($request, PermissionHelper::PERM_LIVEMAP)) {
             abort(401);
         }
-
         $rawServerIps = explode(',', env('OP_FW_SERVERS', ''));
         $serverIps = [];
         foreach ($rawServerIps as $index => $rawServerIp) {


### PR DESCRIPTION
Added a setting to allow each Sub-Division to decide if they want to restrict access to the live map. (Defaults to True)

Can be reverted to original settings (All staff can see live map) by setting LOCK_MAP_TO_ROLE to false in the .env file